### PR TITLE
Update get_data_ids so it works for compressed files

### DIFF
--- a/examples/02_zenodo_data_store_preload_zip.ipynb
+++ b/examples/02_zenodo_data_store_preload_zip.ipynb
@@ -25,8 +25,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 3.37 s, sys: 342 ms, total: 3.71 s\n",
-      "Wall time: 3.93 s\n"
+      "CPU times: user 2.95 s, sys: 185 ms, total: 3.13 s\n",
+      "Wall time: 1.22 s\n"
      ]
     }
    ],
@@ -53,8 +53,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 47.7 ms, sys: 13.3 ms, total: 61 ms\n",
-      "Wall time: 228 ms\n"
+      "CPU times: user 29.4 ms, sys: 8.06 ms, total: 37.5 ms\n",
+      "Wall time: 36.7 ms\n"
      ]
     },
     {
@@ -90,7 +90,7 @@
        "type": "object"
       },
       "text/plain": [
-       "<xcube.util.jsonschema.JsonObjectSchema at 0x7cb183fbd010>"
+       "<xcube.util.jsonschema.JsonObjectSchema at 0x7ea6adf78c20>"
       ]
      },
      "execution_count": 2,
@@ -120,8 +120,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 7.26 ms, sys: 912 μs, total: 8.18 ms\n",
-      "Wall time: 8.24 ms\n"
+      "CPU times: user 5.64 ms, sys: 0 ns, total: 5.64 ms\n",
+      "Wall time: 5.59 ms\n"
      ]
     }
    ],
@@ -134,7 +134,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Compressed files can be preloaded using the `preload_data` method. This approach enables the downloading of compressed files that cannot be lazily loaded, allowing them to be stored and readily available for the duration of the project. Also this method uses `preload_params`, which can be viewed in the next cell."
+    "We can list the data IDs, which already tell us that we need to preload the data, since the available files in the records are all zip files. If the user tries to use `open_data()` to access a compressed data source, the store will raise an error and notify the user that `preload_data()` may be used.  "
    ]
   },
   {
@@ -146,8 +146,81 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 47 μs, sys: 6 μs, total: 53 μs\n",
-      "Wall time: 56 μs\n"
+      "CPU times: user 6.52 ms, sys: 1.87 ms, total: 8.39 ms\n",
+      "Wall time: 634 ms\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['italy.zip',\n",
+       " 'luxembourg.zip',\n",
+       " 'andorra.zip',\n",
+       " 'switzerland.zip',\n",
+       " 'albania.zip',\n",
+       " 'denmark.zip',\n",
+       " 'finland.zip',\n",
+       " 'slovakia.zip',\n",
+       " 'germany.zip',\n",
+       " 'bosniaherzegovina.zip',\n",
+       " 'belgium.zip',\n",
+       " 'bulgaria.zip',\n",
+       " 'croatia.zip',\n",
+       " 'liechtenstein.zip',\n",
+       " 'czechia.zip',\n",
+       " 'spain.zip',\n",
+       " 'slovenia.zip',\n",
+       " 'austria.zip',\n",
+       " 'latvia.zip',\n",
+       " 'portugal.zip',\n",
+       " 'poland.zip',\n",
+       " 'france.zip',\n",
+       " 'ireland.zip',\n",
+       " 'romania.zip',\n",
+       " 'serbia.zip',\n",
+       " 'hungary.zip',\n",
+       " 'norway.zip',\n",
+       " 'netherlands.zip',\n",
+       " 'unitedkingdom.zip',\n",
+       " 'macedonia.zip',\n",
+       " 'greece.zip',\n",
+       " 'lithuania.zip',\n",
+       " 'moldova.zip',\n",
+       " 'montenegro.zip',\n",
+       " 'estonia.zip',\n",
+       " 'ukraine.zip',\n",
+       " 'belarus.zip',\n",
+       " 'sweden.zip']"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "store.list_data_ids()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Compressed files can be preloaded using the `preload_data` method. This approach enables the downloading of compressed files that cannot be lazily loaded, allowing them to be stored and readily available for the duration of the project. Also this method uses `preload_params`, which can be viewed in the next cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 30 μs, sys: 3 μs, total: 33 μs\n",
+      "Wall time: 34.1 μs\n"
      ]
     },
     {
@@ -171,10 +244,10 @@
        "type": "object"
       },
       "text/plain": [
-       "<xcube.util.jsonschema.JsonObjectSchema at 0x7cb24cf20920>"
+       "<xcube.util.jsonschema.JsonObjectSchema at 0x7ea6adce8710>"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -194,13 +267,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5f976cfa01d84278a1b7b407b49e5a6f",
+       "model_id": "bbee89a43b2f4a40b26f32e07f11d376",
        "version_major": 2,
        "version_minor": 0
       },
@@ -225,7 +298,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {
     "scrolled": true
    },
@@ -253,7 +326,7 @@
        " 'andorra/greatest_disturbance_andorra.zarr']"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -271,15 +344,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 1.27 ms, sys: 56 μs, total: 1.32 ms\n",
-      "Wall time: 1.35 ms\n"
+      "CPU times: user 866 μs, sys: 0 ns, total: 866 μs\n",
+      "Wall time: 870 μs\n"
      ]
     },
     {
@@ -316,8 +389,8 @@
         },
         "data_type": {
          "enum": [
-          "dataset",
           "mldataset",
+          "dataset",
           "geodataframe"
          ],
          "title": "Optional data type",
@@ -363,10 +436,10 @@
        "type": "object"
       },
       "text/plain": [
-       "<xcube.util.jsonschema.JsonObjectSchema at 0x7cb182892480>"
+       "<xcube.util.jsonschema.JsonObjectSchema at 0x7ea6ac7e3aa0>"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -379,15 +452,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 45.1 ms, sys: 3.15 ms, total: 48.2 ms\n",
-      "Wall time: 47.5 ms\n"
+      "CPU times: user 62.8 ms, sys: 2.96 ms, total: 65.8 ms\n",
+      "Wall time: 65.2 ms\n"
      ]
     },
     {
@@ -784,9 +857,9 @@
        "    band_8       (y, x) float64 9MB dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;\n",
        "    band_9       (y, x) float64 9MB dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;\n",
        "Attributes:\n",
-       "    source:   file:///home/konstantin/bc_kon/01_coding/01_github/xcube-zenodo...</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-5d01d440-2b9e-44fb-8c18-b9b4db7307c0' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-5d01d440-2b9e-44fb-8c18-b9b4db7307c0' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>y</span>: 971</li><li><span class='xr-has-index'>x</span>: 1149</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-7de31ff1-8094-449a-bf44-b43b70fc9333' class='xr-section-summary-in' type='checkbox'  checked><label for='section-7de31ff1-8094-449a-bf44-b43b70fc9333' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>spatial_ref</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-b2e013c2-f734-4c6a-b290-2396476128c4' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b2e013c2-f734-4c6a-b290-2396476128c4' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-be589e43-e1de-4b11-9826-cbe762e4f67a' class='xr-var-data-in' type='checkbox'><label for='data-be589e43-e1de-4b11-9826-cbe762e4f67a' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>GeoTransform :</span></dt><dd>3612821.730541179 30.0 0.0 2214452.6274675243 0.0 -30.0</dd><dt><span>crs_wkt :</span></dt><dd>PROJCS[&quot;ETRS89-extended / LAEA Europe&quot;,GEOGCS[&quot;ETRS89&quot;,DATUM[&quot;European_Terrestrial_Reference_System_1989&quot;,SPHEROID[&quot;GRS 1980&quot;,6378137,298.257222101,AUTHORITY[&quot;EPSG&quot;,&quot;7019&quot;]],AUTHORITY[&quot;EPSG&quot;,&quot;6258&quot;]],PRIMEM[&quot;Greenwich&quot;,0,AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],UNIT[&quot;degree&quot;,0.0174532925199433,AUTHORITY[&quot;EPSG&quot;,&quot;9122&quot;]],AUTHORITY[&quot;EPSG&quot;,&quot;4258&quot;]],PROJECTION[&quot;Lambert_Azimuthal_Equal_Area&quot;],PARAMETER[&quot;latitude_of_center&quot;,52],PARAMETER[&quot;longitude_of_center&quot;,10],PARAMETER[&quot;false_easting&quot;,4321000],PARAMETER[&quot;false_northing&quot;,3210000],UNIT[&quot;metre&quot;,1,AUTHORITY[&quot;EPSG&quot;,&quot;9001&quot;]],AXIS[&quot;Northing&quot;,NORTH],AXIS[&quot;Easting&quot;,EAST],AUTHORITY[&quot;EPSG&quot;,&quot;3035&quot;]]</dd><dt><span>false_easting :</span></dt><dd>4321000.0</dd><dt><span>false_northing :</span></dt><dd>3210000.0</dd><dt><span>geographic_crs_name :</span></dt><dd>ETRS89</dd><dt><span>grid_mapping_name :</span></dt><dd>lambert_azimuthal_equal_area</dd><dt><span>horizontal_datum_name :</span></dt><dd>European Terrestrial Reference System 1989</dd><dt><span>inverse_flattening :</span></dt><dd>298.257222101</dd><dt><span>latitude_of_projection_origin :</span></dt><dd>52.0</dd><dt><span>longitude_of_prime_meridian :</span></dt><dd>0.0</dd><dt><span>longitude_of_projection_origin :</span></dt><dd>10.0</dd><dt><span>prime_meridian_name :</span></dt><dd>Greenwich</dd><dt><span>projected_crs_name :</span></dt><dd>ETRS89-extended / LAEA Europe</dd><dt><span>reference_ellipsoid_name :</span></dt><dd>GRS 1980</dd><dt><span>semi_major_axis :</span></dt><dd>6378137.0</dd><dt><span>semi_minor_axis :</span></dt><dd>6356752.314140356</dd><dt><span>spatial_ref :</span></dt><dd>PROJCS[&quot;ETRS89-extended / LAEA Europe&quot;,GEOGCS[&quot;ETRS89&quot;,DATUM[&quot;European_Terrestrial_Reference_System_1989&quot;,SPHEROID[&quot;GRS 1980&quot;,6378137,298.257222101,AUTHORITY[&quot;EPSG&quot;,&quot;7019&quot;]],AUTHORITY[&quot;EPSG&quot;,&quot;6258&quot;]],PRIMEM[&quot;Greenwich&quot;,0,AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],UNIT[&quot;degree&quot;,0.0174532925199433,AUTHORITY[&quot;EPSG&quot;,&quot;9122&quot;]],AUTHORITY[&quot;EPSG&quot;,&quot;4258&quot;]],PROJECTION[&quot;Lambert_Azimuthal_Equal_Area&quot;],PARAMETER[&quot;latitude_of_center&quot;,52],PARAMETER[&quot;longitude_of_center&quot;,10],PARAMETER[&quot;false_easting&quot;,4321000],PARAMETER[&quot;false_northing&quot;,3210000],UNIT[&quot;metre&quot;,1,AUTHORITY[&quot;EPSG&quot;,&quot;9001&quot;]],AXIS[&quot;Northing&quot;,NORTH],AXIS[&quot;Easting&quot;,EAST],AUTHORITY[&quot;EPSG&quot;,&quot;3035&quot;]]</dd></dl></div><div class='xr-var-data'><pre>[1 values with dtype=int64]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>3.613e+06 3.613e+06 ... 3.647e+06</div><input id='attrs-8729f3aa-8670-4002-b0bc-1e92f5c6efc7' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-8729f3aa-8670-4002-b0bc-1e92f5c6efc7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-94e0d545-7aa1-4877-8633-5962cb553d86' class='xr-var-data-in' type='checkbox'><label for='data-94e0d545-7aa1-4877-8633-5962cb553d86' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([3612836.730541, 3612866.730541, 3612896.730541, ..., 3647216.730541,\n",
-       "       3647246.730541, 3647276.730541])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>2.214e+06 2.214e+06 ... 2.185e+06</div><input id='attrs-c1ec566b-4543-465e-8910-d18a4a69f9d6' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-c1ec566b-4543-465e-8910-d18a4a69f9d6' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bd58c2ae-3833-40bb-bdd4-e725eb866d58' class='xr-var-data-in' type='checkbox'><label for='data-bd58c2ae-3833-40bb-bdd4-e725eb866d58' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([2214437.627468, 2214407.627468, 2214377.627468, ..., 2185397.627468,\n",
-       "       2185367.627468, 2185337.627468])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-ec705484-b56d-4ef7-bd5d-3bea99482513' class='xr-section-summary-in' type='checkbox'  ><label for='section-ec705484-b56d-4ef7-bd5d-3bea99482513' class='xr-section-summary' >Data variables: <span>(39)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>band_1</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-bf8a0d99-c20a-4185-81c8-c1780f86fa9e' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-bf8a0d99-c20a-4185-81c8-c1780f86fa9e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3227e7a7-a788-4065-8290-b0cbc6e32a85' class='xr-var-data-in' type='checkbox'><label for='data-3227e7a7-a788-4065-8290-b0cbc6e32a85' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "    source:   file:///home/konstantin/bc_kon/01_coding/01_github/xcube-zenodo...</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-474001e7-b6c1-4a2b-8b17-de2382917dcc' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-474001e7-b6c1-4a2b-8b17-de2382917dcc' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>y</span>: 971</li><li><span class='xr-has-index'>x</span>: 1149</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-bbf26191-8f56-4f93-ae4d-7eda1f08c405' class='xr-section-summary-in' type='checkbox'  checked><label for='section-bbf26191-8f56-4f93-ae4d-7eda1f08c405' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>spatial_ref</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-f660308f-6c0c-4e5b-af76-02d6f6c3d0dc' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f660308f-6c0c-4e5b-af76-02d6f6c3d0dc' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d9169451-03c4-4ee4-9ac7-1e431cb24cf2' class='xr-var-data-in' type='checkbox'><label for='data-d9169451-03c4-4ee4-9ac7-1e431cb24cf2' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>GeoTransform :</span></dt><dd>3612821.730541179 30.0 0.0 2214452.6274675243 0.0 -30.0</dd><dt><span>crs_wkt :</span></dt><dd>PROJCS[&quot;ETRS89-extended / LAEA Europe&quot;,GEOGCS[&quot;ETRS89&quot;,DATUM[&quot;European_Terrestrial_Reference_System_1989&quot;,SPHEROID[&quot;GRS 1980&quot;,6378137,298.257222101,AUTHORITY[&quot;EPSG&quot;,&quot;7019&quot;]],AUTHORITY[&quot;EPSG&quot;,&quot;6258&quot;]],PRIMEM[&quot;Greenwich&quot;,0,AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],UNIT[&quot;degree&quot;,0.0174532925199433,AUTHORITY[&quot;EPSG&quot;,&quot;9122&quot;]],AUTHORITY[&quot;EPSG&quot;,&quot;4258&quot;]],PROJECTION[&quot;Lambert_Azimuthal_Equal_Area&quot;],PARAMETER[&quot;latitude_of_center&quot;,52],PARAMETER[&quot;longitude_of_center&quot;,10],PARAMETER[&quot;false_easting&quot;,4321000],PARAMETER[&quot;false_northing&quot;,3210000],UNIT[&quot;metre&quot;,1,AUTHORITY[&quot;EPSG&quot;,&quot;9001&quot;]],AXIS[&quot;Northing&quot;,NORTH],AXIS[&quot;Easting&quot;,EAST],AUTHORITY[&quot;EPSG&quot;,&quot;3035&quot;]]</dd><dt><span>false_easting :</span></dt><dd>4321000.0</dd><dt><span>false_northing :</span></dt><dd>3210000.0</dd><dt><span>geographic_crs_name :</span></dt><dd>ETRS89</dd><dt><span>grid_mapping_name :</span></dt><dd>lambert_azimuthal_equal_area</dd><dt><span>horizontal_datum_name :</span></dt><dd>European Terrestrial Reference System 1989</dd><dt><span>inverse_flattening :</span></dt><dd>298.257222101</dd><dt><span>latitude_of_projection_origin :</span></dt><dd>52.0</dd><dt><span>longitude_of_prime_meridian :</span></dt><dd>0.0</dd><dt><span>longitude_of_projection_origin :</span></dt><dd>10.0</dd><dt><span>prime_meridian_name :</span></dt><dd>Greenwich</dd><dt><span>projected_crs_name :</span></dt><dd>ETRS89-extended / LAEA Europe</dd><dt><span>reference_ellipsoid_name :</span></dt><dd>GRS 1980</dd><dt><span>semi_major_axis :</span></dt><dd>6378137.0</dd><dt><span>semi_minor_axis :</span></dt><dd>6356752.314140356</dd><dt><span>spatial_ref :</span></dt><dd>PROJCS[&quot;ETRS89-extended / LAEA Europe&quot;,GEOGCS[&quot;ETRS89&quot;,DATUM[&quot;European_Terrestrial_Reference_System_1989&quot;,SPHEROID[&quot;GRS 1980&quot;,6378137,298.257222101,AUTHORITY[&quot;EPSG&quot;,&quot;7019&quot;]],AUTHORITY[&quot;EPSG&quot;,&quot;6258&quot;]],PRIMEM[&quot;Greenwich&quot;,0,AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],UNIT[&quot;degree&quot;,0.0174532925199433,AUTHORITY[&quot;EPSG&quot;,&quot;9122&quot;]],AUTHORITY[&quot;EPSG&quot;,&quot;4258&quot;]],PROJECTION[&quot;Lambert_Azimuthal_Equal_Area&quot;],PARAMETER[&quot;latitude_of_center&quot;,52],PARAMETER[&quot;longitude_of_center&quot;,10],PARAMETER[&quot;false_easting&quot;,4321000],PARAMETER[&quot;false_northing&quot;,3210000],UNIT[&quot;metre&quot;,1,AUTHORITY[&quot;EPSG&quot;,&quot;9001&quot;]],AXIS[&quot;Northing&quot;,NORTH],AXIS[&quot;Easting&quot;,EAST],AUTHORITY[&quot;EPSG&quot;,&quot;3035&quot;]]</dd></dl></div><div class='xr-var-data'><pre>[1 values with dtype=int64]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>3.613e+06 3.613e+06 ... 3.647e+06</div><input id='attrs-ee84c74f-384c-459e-a970-27fd361139ea' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-ee84c74f-384c-459e-a970-27fd361139ea' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c72d96ec-f37b-49e7-a720-236edb0fba17' class='xr-var-data-in' type='checkbox'><label for='data-c72d96ec-f37b-49e7-a720-236edb0fba17' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([3612836.730541, 3612866.730541, 3612896.730541, ..., 3647216.730541,\n",
+       "       3647246.730541, 3647276.730541])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>2.214e+06 2.214e+06 ... 2.185e+06</div><input id='attrs-a4bf396e-5e06-4b5f-b64e-775eeef5c633' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-a4bf396e-5e06-4b5f-b64e-775eeef5c633' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-12a45cd6-6d44-4d79-a1c2-2150284d30c5' class='xr-var-data-in' type='checkbox'><label for='data-12a45cd6-6d44-4d79-a1c2-2150284d30c5' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([2214437.627468, 2214407.627468, 2214377.627468, ..., 2185397.627468,\n",
+       "       2185367.627468, 2185337.627468])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-8c0762ed-a4ad-4424-aebe-bbf7da490716' class='xr-section-summary-in' type='checkbox'  ><label for='section-8c0762ed-a4ad-4424-aebe-bbf7da490716' class='xr-section-summary' >Data variables: <span>(39)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>band_1</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-f2a7bed0-f8c3-4fbc-ab82-ff4430254fe5' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f2a7bed0-f8c3-4fbc-ab82-ff4430254fe5' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-cd7ebdd2-c076-433b-992b-aed0d138e38f' class='xr-var-data-in' type='checkbox'><label for='data-cd7ebdd2-c076-433b-992b-aed0d138e38f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -844,7 +917,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_10</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-56a9f692-a727-4994-a907-371aa9965d8f' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-56a9f692-a727-4994-a907-371aa9965d8f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a6f70e5f-1ac4-46c2-82e6-df550f13132b' class='xr-var-data-in' type='checkbox'><label for='data-a6f70e5f-1ac4-46c2-82e6-df550f13132b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_10</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-6f36037c-b6a0-4a5d-9926-829c49fa83e1' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-6f36037c-b6a0-4a5d-9926-829c49fa83e1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-55264efd-c9f6-415d-8d2f-3b8c4f12a261' class='xr-var-data-in' type='checkbox'><label for='data-55264efd-c9f6-415d-8d2f-3b8c4f12a261' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -902,7 +975,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_11</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-a39eb067-d16b-4646-9a9d-457ff816f679' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-a39eb067-d16b-4646-9a9d-457ff816f679' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2ad2d37d-f11d-4f65-8b50-7872db08ae08' class='xr-var-data-in' type='checkbox'><label for='data-2ad2d37d-f11d-4f65-8b50-7872db08ae08' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_11</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-f4550ecc-323d-4c00-9102-17dc6496975e' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f4550ecc-323d-4c00-9102-17dc6496975e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a5ba3894-815e-4550-9bd8-ba7c7740b053' class='xr-var-data-in' type='checkbox'><label for='data-a5ba3894-815e-4550-9bd8-ba7c7740b053' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -960,7 +1033,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_12</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-c547d839-733e-46f0-812d-50298e6bfacb' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c547d839-733e-46f0-812d-50298e6bfacb' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-083ca13c-d096-40cf-a495-2d4a8e3b28ab' class='xr-var-data-in' type='checkbox'><label for='data-083ca13c-d096-40cf-a495-2d4a8e3b28ab' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_12</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-07f14293-88cf-4eec-bdbe-fae17dc6e07b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-07f14293-88cf-4eec-bdbe-fae17dc6e07b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7cfe94c2-8cb2-4c4f-aa31-23f468a6d466' class='xr-var-data-in' type='checkbox'><label for='data-7cfe94c2-8cb2-4c4f-aa31-23f468a6d466' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -1018,7 +1091,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_13</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-0d7457bb-d558-4e9c-8f5c-34e3a449afef' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-0d7457bb-d558-4e9c-8f5c-34e3a449afef' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a15b96dc-dfc4-4fe7-8d11-cc86044816c8' class='xr-var-data-in' type='checkbox'><label for='data-a15b96dc-dfc4-4fe7-8d11-cc86044816c8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_13</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-24d89e62-5b7a-41dd-9c0e-9b2b0bcde567' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-24d89e62-5b7a-41dd-9c0e-9b2b0bcde567' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-fcb3dfec-28b6-429d-992b-bb7a1b816bfd' class='xr-var-data-in' type='checkbox'><label for='data-fcb3dfec-28b6-429d-992b-bb7a1b816bfd' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -1076,7 +1149,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_14</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-a4745047-56b7-4165-aab0-c5c56ed99b8a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-a4745047-56b7-4165-aab0-c5c56ed99b8a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3b9f1f6c-ac5a-4fe7-8a84-c95bc23b29e7' class='xr-var-data-in' type='checkbox'><label for='data-3b9f1f6c-ac5a-4fe7-8a84-c95bc23b29e7' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_14</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-bc175131-c649-4602-ae76-e847084cd780' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-bc175131-c649-4602-ae76-e847084cd780' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1cd01255-8e9d-4a61-ad22-cf0255dc9a61' class='xr-var-data-in' type='checkbox'><label for='data-1cd01255-8e9d-4a61-ad22-cf0255dc9a61' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -1134,7 +1207,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_15</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-c4de38ae-26d8-46d5-9356-262ba680a74d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c4de38ae-26d8-46d5-9356-262ba680a74d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-08d620ec-8f5d-4a83-8851-226f4b3e6fd4' class='xr-var-data-in' type='checkbox'><label for='data-08d620ec-8f5d-4a83-8851-226f4b3e6fd4' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_15</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-7b8b1d6f-d3a4-411b-b4e1-b1180b50bb98' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-7b8b1d6f-d3a4-411b-b4e1-b1180b50bb98' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-12aec0b6-d2a1-4c1f-b002-f540335c02c3' class='xr-var-data-in' type='checkbox'><label for='data-12aec0b6-d2a1-4c1f-b002-f540335c02c3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -1192,7 +1265,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_16</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-de14b482-0460-4f6c-95cd-1f490c5a182d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-de14b482-0460-4f6c-95cd-1f490c5a182d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-49901893-de1b-4fea-a111-f60db915a897' class='xr-var-data-in' type='checkbox'><label for='data-49901893-de1b-4fea-a111-f60db915a897' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_16</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-757b6c44-9f19-4a09-8c84-e571a0fed71a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-757b6c44-9f19-4a09-8c84-e571a0fed71a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8441ed3e-e3f1-4bfa-9806-b17fd005224d' class='xr-var-data-in' type='checkbox'><label for='data-8441ed3e-e3f1-4bfa-9806-b17fd005224d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -1250,7 +1323,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_17</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-6caaec59-f699-4bbc-a2b9-cc3d6092c534' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-6caaec59-f699-4bbc-a2b9-cc3d6092c534' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e00fa4c7-355a-419d-8fed-fdb24b1e309e' class='xr-var-data-in' type='checkbox'><label for='data-e00fa4c7-355a-419d-8fed-fdb24b1e309e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_17</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-6f0287de-006b-4b16-90c4-ae675d05cc65' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-6f0287de-006b-4b16-90c4-ae675d05cc65' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e38df306-6f1a-4c44-890c-2cf0f5070eca' class='xr-var-data-in' type='checkbox'><label for='data-e38df306-6f1a-4c44-890c-2cf0f5070eca' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -1308,7 +1381,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_18</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-06daa826-be65-46c7-9c41-bf6354b60dcd' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-06daa826-be65-46c7-9c41-bf6354b60dcd' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b18ca9ef-b37f-4fd3-80ea-50a3efdbefad' class='xr-var-data-in' type='checkbox'><label for='data-b18ca9ef-b37f-4fd3-80ea-50a3efdbefad' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_18</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-fed9d8e1-0c75-4450-85fe-ed33c07cc067' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-fed9d8e1-0c75-4450-85fe-ed33c07cc067' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-81b5c315-a493-4aea-a2cd-c00bc560c1a8' class='xr-var-data-in' type='checkbox'><label for='data-81b5c315-a493-4aea-a2cd-c00bc560c1a8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -1366,7 +1439,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_19</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-97b2ad9a-2d0c-4b0e-9748-8496f33f429c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-97b2ad9a-2d0c-4b0e-9748-8496f33f429c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d18555cd-2365-4717-93b6-ddb9ff341052' class='xr-var-data-in' type='checkbox'><label for='data-d18555cd-2365-4717-93b6-ddb9ff341052' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_19</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-93724b0e-73e8-479b-8be4-46077446a1c3' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-93724b0e-73e8-479b-8be4-46077446a1c3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ec38b483-0db7-4adb-b374-bdfc2710d86c' class='xr-var-data-in' type='checkbox'><label for='data-ec38b483-0db7-4adb-b374-bdfc2710d86c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -1424,7 +1497,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_2</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-e467a49e-7e27-4a02-aaf2-8349bab82606' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e467a49e-7e27-4a02-aaf2-8349bab82606' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-aad784e1-879d-4591-9911-13dd2e0a915b' class='xr-var-data-in' type='checkbox'><label for='data-aad784e1-879d-4591-9911-13dd2e0a915b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_2</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-f43f5495-c163-485c-a5b6-64d901923bda' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f43f5495-c163-485c-a5b6-64d901923bda' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-39fada39-78d7-468c-852a-25d89c1f4121' class='xr-var-data-in' type='checkbox'><label for='data-39fada39-78d7-468c-852a-25d89c1f4121' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -1482,7 +1555,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_20</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-e944362b-758f-48ae-a676-5dd6470ddc93' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e944362b-758f-48ae-a676-5dd6470ddc93' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e945e970-4d11-4d89-a3f4-d915c6a7d560' class='xr-var-data-in' type='checkbox'><label for='data-e945e970-4d11-4d89-a3f4-d915c6a7d560' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_20</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-44478112-ad7b-45b6-97e3-71ca1eff1ca3' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-44478112-ad7b-45b6-97e3-71ca1eff1ca3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7c33b2dd-ca53-47b7-8f39-5736ff1be965' class='xr-var-data-in' type='checkbox'><label for='data-7c33b2dd-ca53-47b7-8f39-5736ff1be965' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -1540,7 +1613,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_21</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-ae356598-81ab-467a-b39b-340a083f79da' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ae356598-81ab-467a-b39b-340a083f79da' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5a780034-94fd-479f-b66d-6ed95b089785' class='xr-var-data-in' type='checkbox'><label for='data-5a780034-94fd-479f-b66d-6ed95b089785' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_21</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-e72268b0-c7f9-4553-8970-fe286ff66cd3' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e72268b0-c7f9-4553-8970-fe286ff66cd3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bddc5ed7-4485-4bba-b942-fa1b291768fb' class='xr-var-data-in' type='checkbox'><label for='data-bddc5ed7-4485-4bba-b942-fa1b291768fb' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -1598,7 +1671,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_22</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-ce3daf2c-8bf1-405a-868f-284b8405bdea' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ce3daf2c-8bf1-405a-868f-284b8405bdea' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-226ff389-504a-4d41-bf26-dd99bc61f125' class='xr-var-data-in' type='checkbox'><label for='data-226ff389-504a-4d41-bf26-dd99bc61f125' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_22</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-542f963e-9e7c-4930-ab48-e43f97e5557c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-542f963e-9e7c-4930-ab48-e43f97e5557c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d3625778-a24e-48df-8322-48fedb11c992' class='xr-var-data-in' type='checkbox'><label for='data-d3625778-a24e-48df-8322-48fedb11c992' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -1656,7 +1729,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_23</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-7dada7c7-7030-42a7-94d8-4747a70b99be' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-7dada7c7-7030-42a7-94d8-4747a70b99be' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bfd2d785-9b29-4f65-9cb5-3ecdc796d735' class='xr-var-data-in' type='checkbox'><label for='data-bfd2d785-9b29-4f65-9cb5-3ecdc796d735' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_23</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-cb86e07c-66ef-4f6e-82b0-f397b7184829' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-cb86e07c-66ef-4f6e-82b0-f397b7184829' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1e7ed9ca-f121-496f-81f2-a25e9ce6e634' class='xr-var-data-in' type='checkbox'><label for='data-1e7ed9ca-f121-496f-81f2-a25e9ce6e634' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -1714,7 +1787,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_24</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-2b5ad894-3e7d-421f-be3a-eacb5d29018d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2b5ad894-3e7d-421f-be3a-eacb5d29018d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-9bb48bbe-dd10-4f6f-b6c2-9ac0c9917175' class='xr-var-data-in' type='checkbox'><label for='data-9bb48bbe-dd10-4f6f-b6c2-9ac0c9917175' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_24</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-afaac023-3886-45f4-8959-94bc31ecceec' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-afaac023-3886-45f4-8959-94bc31ecceec' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6024d833-6c94-4477-81eb-e3d8bffe1542' class='xr-var-data-in' type='checkbox'><label for='data-6024d833-6c94-4477-81eb-e3d8bffe1542' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -1772,7 +1845,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_25</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-53a98d79-c4ef-4cbd-a1b6-bcc563af658f' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-53a98d79-c4ef-4cbd-a1b6-bcc563af658f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-178e6116-a73d-4efe-95fe-714e6d758adf' class='xr-var-data-in' type='checkbox'><label for='data-178e6116-a73d-4efe-95fe-714e6d758adf' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_25</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-46808bd3-6fa3-4a12-acf9-2da9b49824dd' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-46808bd3-6fa3-4a12-acf9-2da9b49824dd' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bd45e184-df35-44fb-a7c3-41231b9b3b1e' class='xr-var-data-in' type='checkbox'><label for='data-bd45e184-df35-44fb-a7c3-41231b9b3b1e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -1830,7 +1903,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_26</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-7d8589c2-e722-49ed-9fe5-a5e643cd31bf' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-7d8589c2-e722-49ed-9fe5-a5e643cd31bf' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0e377476-705e-476a-be81-b7b549702d07' class='xr-var-data-in' type='checkbox'><label for='data-0e377476-705e-476a-be81-b7b549702d07' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_26</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-308eaff5-1df2-4a43-b26b-5f44d4509fd4' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-308eaff5-1df2-4a43-b26b-5f44d4509fd4' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-95b9dc0a-fe25-4436-8840-8c47034f95e0' class='xr-var-data-in' type='checkbox'><label for='data-95b9dc0a-fe25-4436-8840-8c47034f95e0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -1888,7 +1961,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_27</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-16805179-ff87-4cec-a39b-fa31e8967d8d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-16805179-ff87-4cec-a39b-fa31e8967d8d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a7350faa-3aff-491b-913a-02c7e59cf3ca' class='xr-var-data-in' type='checkbox'><label for='data-a7350faa-3aff-491b-913a-02c7e59cf3ca' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_27</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-b0b9871e-62ef-4b55-b81c-71eadfa9bc94' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b0b9871e-62ef-4b55-b81c-71eadfa9bc94' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-08b420c5-7e90-4dbe-9ce5-d6388258c968' class='xr-var-data-in' type='checkbox'><label for='data-08b420c5-7e90-4dbe-9ce5-d6388258c968' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -1946,7 +2019,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_28</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-daf6801b-eaf9-465d-95c9-726222f31ff7' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-daf6801b-eaf9-465d-95c9-726222f31ff7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-64126593-11c3-40a6-b8f2-1c81e9717d69' class='xr-var-data-in' type='checkbox'><label for='data-64126593-11c3-40a6-b8f2-1c81e9717d69' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_28</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-f24163d0-5d9f-45d1-8520-9cb7b709534c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f24163d0-5d9f-45d1-8520-9cb7b709534c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-9e0c032e-6264-4a5c-9f47-e9add9e80de2' class='xr-var-data-in' type='checkbox'><label for='data-9e0c032e-6264-4a5c-9f47-e9add9e80de2' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -2004,7 +2077,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_29</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-3aa4aa94-9933-43ce-b817-cbba66315827' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-3aa4aa94-9933-43ce-b817-cbba66315827' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-16f707fd-3895-46f9-b917-b05e60d65ee5' class='xr-var-data-in' type='checkbox'><label for='data-16f707fd-3895-46f9-b917-b05e60d65ee5' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_29</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-24f4a28a-caee-43ef-b282-e17415b13313' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-24f4a28a-caee-43ef-b282-e17415b13313' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-41d11ef9-8718-4414-ad49-619cab930205' class='xr-var-data-in' type='checkbox'><label for='data-41d11ef9-8718-4414-ad49-619cab930205' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -2062,7 +2135,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_3</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-3f2b7856-2ce8-4573-9cff-1252c4bce92f' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-3f2b7856-2ce8-4573-9cff-1252c4bce92f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ab51aa4a-b784-4bf1-a846-d33744b9c8d9' class='xr-var-data-in' type='checkbox'><label for='data-ab51aa4a-b784-4bf1-a846-d33744b9c8d9' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_3</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-8687f0ce-b15c-40aa-b852-2ee8a860f41a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-8687f0ce-b15c-40aa-b852-2ee8a860f41a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f0b6002c-0db5-46da-bf99-abf8e4c8c250' class='xr-var-data-in' type='checkbox'><label for='data-f0b6002c-0db5-46da-bf99-abf8e4c8c250' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -2120,7 +2193,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_30</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-f0c37637-9d5b-4881-bd4f-3e2bf312cfe6' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f0c37637-9d5b-4881-bd4f-3e2bf312cfe6' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-69a71150-bf22-4410-8512-1e4c402bddcf' class='xr-var-data-in' type='checkbox'><label for='data-69a71150-bf22-4410-8512-1e4c402bddcf' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_30</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-a3e996b7-67b8-4a00-a26e-e0f09f629f19' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-a3e996b7-67b8-4a00-a26e-e0f09f629f19' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ba60ba4a-128f-4320-bef1-b7eabfe713ab' class='xr-var-data-in' type='checkbox'><label for='data-ba60ba4a-128f-4320-bef1-b7eabfe713ab' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -2178,7 +2251,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_31</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-1794f807-b120-4d23-9df6-560558449de8' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-1794f807-b120-4d23-9df6-560558449de8' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7fb9386d-9daa-4fbf-bc2e-fa1a8277169e' class='xr-var-data-in' type='checkbox'><label for='data-7fb9386d-9daa-4fbf-bc2e-fa1a8277169e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_31</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-ddaff13c-4d64-4f74-b295-192f6be6c683' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ddaff13c-4d64-4f74-b295-192f6be6c683' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-4d7fc3ff-cfcb-4e4a-8628-c7e2976089f0' class='xr-var-data-in' type='checkbox'><label for='data-4d7fc3ff-cfcb-4e4a-8628-c7e2976089f0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -2236,7 +2309,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_32</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-88c17273-6e7e-4b81-a77e-98809a46b3b8' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-88c17273-6e7e-4b81-a77e-98809a46b3b8' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-73e54984-a68d-4e30-a4dc-1adcd725fb8e' class='xr-var-data-in' type='checkbox'><label for='data-73e54984-a68d-4e30-a4dc-1adcd725fb8e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_32</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-a4998592-7151-479f-a550-94954292cc6f' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-a4998592-7151-479f-a550-94954292cc6f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a502d1d5-463a-4602-b2fb-232c53a3348d' class='xr-var-data-in' type='checkbox'><label for='data-a502d1d5-463a-4602-b2fb-232c53a3348d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -2294,7 +2367,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_33</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-c21ea9f9-d7fc-4026-b24d-99bb2ff7014e' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c21ea9f9-d7fc-4026-b24d-99bb2ff7014e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-9a0f5bd4-dca7-4e20-988c-d3159db58ec4' class='xr-var-data-in' type='checkbox'><label for='data-9a0f5bd4-dca7-4e20-988c-d3159db58ec4' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_33</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-366c0239-47f3-4572-ad5b-7618cf1d06c8' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-366c0239-47f3-4572-ad5b-7618cf1d06c8' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-75790d3e-3050-4f2f-bd00-853543c2f23b' class='xr-var-data-in' type='checkbox'><label for='data-75790d3e-3050-4f2f-bd00-853543c2f23b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -2352,7 +2425,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_34</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-d04125d3-583c-4677-a203-6daba2c6657d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d04125d3-583c-4677-a203-6daba2c6657d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3bc1b62c-3635-438f-84a3-ee1ec772ec97' class='xr-var-data-in' type='checkbox'><label for='data-3bc1b62c-3635-438f-84a3-ee1ec772ec97' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_34</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-6eb09808-4e1a-4be2-8f74-ebe4b8b45f1b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-6eb09808-4e1a-4be2-8f74-ebe4b8b45f1b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2ed1274a-78e0-4ad7-a9d4-46c4223ca658' class='xr-var-data-in' type='checkbox'><label for='data-2ed1274a-78e0-4ad7-a9d4-46c4223ca658' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -2410,7 +2483,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_35</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-15152baf-fa40-41c5-9ccd-2780eb147b7e' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-15152baf-fa40-41c5-9ccd-2780eb147b7e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ff5e03a3-8d94-4147-8010-bf6ed9e4fc71' class='xr-var-data-in' type='checkbox'><label for='data-ff5e03a3-8d94-4147-8010-bf6ed9e4fc71' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_35</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-9530a6d1-cc58-455b-8c78-5044c957f54e' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-9530a6d1-cc58-455b-8c78-5044c957f54e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b86e167c-3b75-4269-bdd4-939b1442ac53' class='xr-var-data-in' type='checkbox'><label for='data-b86e167c-3b75-4269-bdd4-939b1442ac53' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -2468,7 +2541,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_36</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-f0b0d844-fcb6-4105-9c34-6aff0b6d92df' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f0b0d844-fcb6-4105-9c34-6aff0b6d92df' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ddd8648e-4a1a-45ba-b3e4-19e23b46e31b' class='xr-var-data-in' type='checkbox'><label for='data-ddd8648e-4a1a-45ba-b3e4-19e23b46e31b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_36</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-35ec9b81-e241-468a-9f61-44756b5fea1e' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-35ec9b81-e241-468a-9f61-44756b5fea1e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e860729e-d426-42ca-bb42-98a8d754bb64' class='xr-var-data-in' type='checkbox'><label for='data-e860729e-d426-42ca-bb42-98a8d754bb64' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -2526,7 +2599,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_37</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-ae78bd14-f301-43f9-b3b6-9c5de6eb7e2e' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ae78bd14-f301-43f9-b3b6-9c5de6eb7e2e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f7d860fd-e7eb-4516-8476-a65879a0995d' class='xr-var-data-in' type='checkbox'><label for='data-f7d860fd-e7eb-4516-8476-a65879a0995d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_37</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-f6dae83c-216c-4989-a690-acfc72d573ab' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f6dae83c-216c-4989-a690-acfc72d573ab' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-87596929-f583-4908-aee2-68d534d9fe6e' class='xr-var-data-in' type='checkbox'><label for='data-87596929-f583-4908-aee2-68d534d9fe6e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -2584,7 +2657,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_38</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-fad80a83-e1f0-4866-9898-6c1fe0827055' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-fad80a83-e1f0-4866-9898-6c1fe0827055' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-dace205c-8522-4a21-9d2c-0104db161edf' class='xr-var-data-in' type='checkbox'><label for='data-dace205c-8522-4a21-9d2c-0104db161edf' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_38</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-e92851cf-eb86-4843-a012-a3511606a2c1' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e92851cf-eb86-4843-a012-a3511606a2c1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f59fb32b-1d15-4c24-942b-3160467432ef' class='xr-var-data-in' type='checkbox'><label for='data-f59fb32b-1d15-4c24-942b-3160467432ef' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -2642,7 +2715,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_39</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-614715fd-0bee-46a8-9ba8-67a803526f9d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-614715fd-0bee-46a8-9ba8-67a803526f9d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-024e64ce-6cb5-4078-a884-17f73cb1dc3c' class='xr-var-data-in' type='checkbox'><label for='data-024e64ce-6cb5-4078-a884-17f73cb1dc3c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_39</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-23a416b2-b009-4bde-851f-9988c05594ca' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-23a416b2-b009-4bde-851f-9988c05594ca' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-776a31d5-efb3-470d-beda-a5a87218fdb2' class='xr-var-data-in' type='checkbox'><label for='data-776a31d5-efb3-470d-beda-a5a87218fdb2' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -2700,7 +2773,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_4</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-67c52086-13c4-43cb-94e4-5ed8a2e09c02' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-67c52086-13c4-43cb-94e4-5ed8a2e09c02' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2b10fc98-cf5e-4f9a-ac96-126991be3a40' class='xr-var-data-in' type='checkbox'><label for='data-2b10fc98-cf5e-4f9a-ac96-126991be3a40' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_4</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-45b6467e-146c-4ca2-84fa-84e401c646f0' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-45b6467e-146c-4ca2-84fa-84e401c646f0' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6dca389d-5532-4a60-b292-3b1155722d9a' class='xr-var-data-in' type='checkbox'><label for='data-6dca389d-5532-4a60-b292-3b1155722d9a' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -2758,7 +2831,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_5</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-6dcebff8-6f1f-4ce4-a343-483573432ef6' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-6dcebff8-6f1f-4ce4-a343-483573432ef6' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e96b9b5a-5908-4415-8c39-f9a7ca784892' class='xr-var-data-in' type='checkbox'><label for='data-e96b9b5a-5908-4415-8c39-f9a7ca784892' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_5</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-6ec25b75-c5a0-4a68-88f7-3a69b137a5d6' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-6ec25b75-c5a0-4a68-88f7-3a69b137a5d6' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-88d085db-eee3-4c39-9389-672d36b1012d' class='xr-var-data-in' type='checkbox'><label for='data-88d085db-eee3-4c39-9389-672d36b1012d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -2816,7 +2889,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_6</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-9b330baf-b3df-4429-9905-35e58fe15db1' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-9b330baf-b3df-4429-9905-35e58fe15db1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b89b64a9-024b-48fc-bf37-926446e1a067' class='xr-var-data-in' type='checkbox'><label for='data-b89b64a9-024b-48fc-bf37-926446e1a067' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_6</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-168a4611-7880-4151-98c7-d1c19f720a45' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-168a4611-7880-4151-98c7-d1c19f720a45' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f36521fb-3454-486b-ba9f-e0eb79b59549' class='xr-var-data-in' type='checkbox'><label for='data-f36521fb-3454-486b-ba9f-e0eb79b59549' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -2874,7 +2947,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_7</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-07d8e158-25fb-4aec-acae-e2105961289b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-07d8e158-25fb-4aec-acae-e2105961289b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-de873c7f-8c0d-4ee2-917a-b1152ae26c9f' class='xr-var-data-in' type='checkbox'><label for='data-de873c7f-8c0d-4ee2-917a-b1152ae26c9f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_7</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-39c5ae88-b35a-48e7-adce-0188f58a3ab7' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-39c5ae88-b35a-48e7-adce-0188f58a3ab7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-25753e7b-43d2-4495-a701-f589635f8cdc' class='xr-var-data-in' type='checkbox'><label for='data-25753e7b-43d2-4495-a701-f589635f8cdc' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -2932,7 +3005,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_8</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-805cc6d0-6a3f-483f-b09d-1989bf801b21' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-805cc6d0-6a3f-483f-b09d-1989bf801b21' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-4bd3bd2f-fed9-431e-bcf6-97e3d8aa20c6' class='xr-var-data-in' type='checkbox'><label for='data-4bd3bd2f-fed9-431e-bcf6-97e3d8aa20c6' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_8</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-f63a2880-3bb1-4b49-8600-181570e15b5e' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f63a2880-3bb1-4b49-8600-181570e15b5e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-cb314043-21db-4963-8350-cde07fd1841d' class='xr-var-data-in' type='checkbox'><label for='data-cb314043-21db-4963-8350-cde07fd1841d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -2990,7 +3063,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_9</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-794f9ea1-8edd-4cdb-ad40-d6371d6fc496' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-794f9ea1-8edd-4cdb-ad40-d6371d6fc496' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7e33b2f2-de3e-4383-95e0-1657e0309f33' class='xr-var-data-in' type='checkbox'><label for='data-7e33b2f2-de3e-4383-95e0-1657e0309f33' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_9</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(512, 512), meta=np.ndarray&gt;</div><input id='attrs-a6d93e97-a3b8-437d-9c03-6c54ab852d43' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-a6d93e97-a3b8-437d-9c03-6c54ab852d43' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a188ea82-949e-41d9-a34c-f0effcb1e459' class='xr-var-data-in' type='checkbox'><label for='data-a188ea82-949e-41d9-a34c-f0effcb1e459' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -3048,7 +3121,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-9612c908-aa07-4cca-b63b-402d7b0f7daa' class='xr-section-summary-in' type='checkbox'  ><label for='section-9612c908-aa07-4cca-b63b-402d7b0f7daa' class='xr-section-summary' >Indexes: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>x</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-69f1ad02-f32d-4482-a343-096976720fae' class='xr-index-data-in' type='checkbox'/><label for='index-69f1ad02-f32d-4482-a343-096976720fae' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([3612836.730541179, 3612866.730541179, 3612896.730541179,\n",
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-b84355ce-8a74-4346-af00-4228ecacb83c' class='xr-section-summary-in' type='checkbox'  ><label for='section-b84355ce-8a74-4346-af00-4228ecacb83c' class='xr-section-summary' >Indexes: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>x</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-f20e3df0-9b1d-4211-af8f-cc090b14159d' class='xr-index-data-in' type='checkbox'/><label for='index-f20e3df0-9b1d-4211-af8f-cc090b14159d' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([3612836.730541179, 3612866.730541179, 3612896.730541179,\n",
        "       3612926.730541179, 3612956.730541179, 3612986.730541179,\n",
        "       3613016.730541179, 3613046.730541179, 3613076.730541179,\n",
        "       3613106.730541179,\n",
@@ -3057,7 +3130,7 @@
        "       3647096.730541179, 3647126.730541179, 3647156.730541179,\n",
        "       3647186.730541179, 3647216.730541179, 3647246.730541179,\n",
        "       3647276.730541179],\n",
-       "      dtype=&#x27;float64&#x27;, name=&#x27;x&#x27;, length=1149))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>y</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-28b98a95-b19c-4e98-8091-656dea3bf21d' class='xr-index-data-in' type='checkbox'/><label for='index-28b98a95-b19c-4e98-8091-656dea3bf21d' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([2214437.6274675243, 2214407.6274675243, 2214377.6274675243,\n",
+       "      dtype=&#x27;float64&#x27;, name=&#x27;x&#x27;, length=1149))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>y</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-9a2347c0-f6bc-41f5-9c71-034a8be757fc' class='xr-index-data-in' type='checkbox'/><label for='index-9a2347c0-f6bc-41f5-9c71-034a8be757fc' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([2214437.6274675243, 2214407.6274675243, 2214377.6274675243,\n",
        "       2214347.6274675243, 2214317.6274675243, 2214287.6274675243,\n",
        "       2214257.6274675243, 2214227.6274675243, 2214197.6274675243,\n",
        "       2214167.6274675243,\n",
@@ -3066,7 +3139,7 @@
        "       2185517.6274675243, 2185487.6274675243, 2185457.6274675243,\n",
        "       2185427.6274675243, 2185397.6274675243, 2185367.6274675243,\n",
        "       2185337.6274675243],\n",
-       "      dtype=&#x27;float64&#x27;, name=&#x27;y&#x27;, length=971))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-bfa8d62b-6aaf-43a6-849b-e5e3b7ad551b' class='xr-section-summary-in' type='checkbox'  checked><label for='section-bfa8d62b-6aaf-43a6-849b-e5e3b7ad551b' class='xr-section-summary' >Attributes: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>source :</span></dt><dd>file:///home/konstantin/bc_kon/01_coding/01_github/xcube-zenodo/examples/zenodo_cache/13333034/downloads/andorra/disturbance_probability_1985_2023_andorra.tif</dd></dl></div></li></ul></div></div>"
+       "      dtype=&#x27;float64&#x27;, name=&#x27;y&#x27;, length=971))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-e91e0e17-4935-4d1b-89ac-bbb4c10c85a7' class='xr-section-summary-in' type='checkbox'  checked><label for='section-e91e0e17-4935-4d1b-89ac-bbb4c10c85a7' class='xr-section-summary' >Attributes: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>source :</span></dt><dd>file:///home/konstantin/bc_kon/01_coding/01_github/xcube-zenodo/examples/zenodo_cache/13333034/downloads/andorra/disturbance_probability_1985_2023_andorra.tif</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset> Size: 348MB\n",
@@ -3093,7 +3166,7 @@
        "    source:   file:///home/konstantin/bc_kon/01_coding/01_github/xcube-zenodo..."
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3113,24 +3186,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 513 ms, sys: 116 ms, total: 629 ms\n",
-      "Wall time: 795 ms\n"
+      "CPU times: user 320 ms, sys: 36.7 ms, total: 356 ms\n",
+      "Wall time: 346 ms\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.QuadMesh at 0x7cb1800610a0>"
+       "<matplotlib.collections.QuadMesh at 0x7ea6a4d62060>"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     },

--- a/test/test_store.py
+++ b/test/test_store.py
@@ -84,6 +84,7 @@ class ZenodoDataStoreTest(unittest.TestCase):
                 {"key": "planet_canopy_cover_30m_v0.1.tif"},
                 {"key": "planet_agb_30m_v0.1.tif"},
                 {"key": "planet_canopy_height_30m_v0.1.tif"},
+                {"key": "planet_canopy_height_30m_v0.1.zip"},
             ]
         }
         mock_response.status_code = 200
@@ -97,6 +98,7 @@ class ZenodoDataStoreTest(unittest.TestCase):
                 "planet_canopy_cover_30m_v0.1.tif",
                 "planet_agb_30m_v0.1.tif",
                 "planet_canopy_height_30m_v0.1.tif",
+                "planet_canopy_height_30m_v0.1.zip",
             ],
             store.get_data_ids(),
         )

--- a/test/test_store.py
+++ b/test/test_store.py
@@ -84,7 +84,6 @@ class ZenodoDataStoreTest(unittest.TestCase):
                 {"key": "planet_canopy_cover_30m_v0.1.tif"},
                 {"key": "planet_agb_30m_v0.1.tif"},
                 {"key": "planet_canopy_height_30m_v0.1.tif"},
-                {"key": "planet_canopy_height_30m_v0.1.zip"},
             ]
         }
         mock_response.status_code = 200
@@ -98,7 +97,30 @@ class ZenodoDataStoreTest(unittest.TestCase):
                 "planet_canopy_cover_30m_v0.1.tif",
                 "planet_agb_30m_v0.1.tif",
                 "planet_canopy_height_30m_v0.1.tif",
-                "planet_canopy_height_30m_v0.1.zip",
+            ],
+            store.get_data_ids(),
+        )
+
+    @patch("requests.get")
+    def test_get_data_ids_compressed(self, mock_get):
+        # Mock response from Zenodo API
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "files": [
+                {"key": "planet_canopy_cover_30m_v0.1.zip"},
+                {"key": "planet_agb_30m_v0.1.tar"},
+                {"key": "planet_canopy_height_30m_v0.1.tar.gz"},
+            ]
+        }
+        mock_response.status_code = 200
+        mock_get.return_value = mock_response
+        store = new_data_store(DATA_STORE_ID, root="8154445")
+
+        self.assertCountEqual(
+            [
+                "planet_canopy_cover_30m_v0.1.zip",
+                "planet_agb_30m_v0.1.tar",
+                "planet_canopy_height_30m_v0.1.tar.gz",
             ],
             store.get_data_ids(),
         )

--- a/xcube_zenodo/store.py
+++ b/xcube_zenodo/store.py
@@ -102,6 +102,8 @@ class ZenodoDataStore(DataStore):
         for file in files:
             if self._https_data_store.has_data(file["key"]):
                 yield file["key"]
+            elif is_supported_compressed_file_format(file["key"]):
+                yield file["key"]
 
     def has_data(self, data_id: str, data_type: str = None) -> bool:
         return self._https_data_store.has_data(data_id=data_id, data_type=data_type)

--- a/xcube_zenodo/store.py
+++ b/xcube_zenodo/store.py
@@ -100,9 +100,9 @@ class ZenodoDataStore(DataStore):
     ) -> Iterator[str] | Iterator[tuple[str, dict[str, Any]]]:
         files = self._get_files_from_record()
         for file in files:
-            if self._https_data_store.has_data(file["key"]):
-                yield file["key"]
-            elif is_supported_compressed_file_format(file["key"]):
+            if self._https_data_store.has_data(
+                file["key"]
+            ) or is_supported_compressed_file_format(file["key"]):
                 yield file["key"]
 
     def has_data(self, data_id: str, data_type: str = None) -> bool:


### PR DESCRIPTION
The `get_data_ids()` method now recognizes compressed files, so that also compressed files (zip, tar, tar.gz) will be listed. 